### PR TITLE
Make SXSEXP long path aware

### DIFF
--- a/Source/sxsexp/sxsexp.manifest
+++ b/Source/sxsexp/sxsexp.manifest
@@ -26,6 +26,11 @@
             <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
         </application> 
     </compatibility>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <ws2:longPathAware>true</ws2:longPathAware>
+        </windowsSettings>
+    </application>
 
   <dependency>
     <dependentAssembly>


### PR DESCRIPTION
See [Enable Long Paths in Windows 10, Version 1607, and Later](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later).