### PR TITLE
Improve error handling, skip unknown files, abort on first error

### DIFF
--- a/Source/sxsexp/sup.c
+++ b/Source/sxsexp/sup.c
@@ -401,12 +401,13 @@ VOID supPrintDeltaHeaderInfo(
 *
 */
 CFILE_TYPE supGetFileType(
-    _In_ PVOID FileBuffer
+    _In_ PVOID FileBuffer,
+	_In_ ULONG fileSize
 )
 {
     CFILE_TYPE Result = ftUnknown;
 
-    if (FileBuffer == NULL)
+    if (FileBuffer == NULL || fileSize < 4)
         return ftUnknown;
 
     //
@@ -447,17 +448,6 @@ CFILE_TYPE supGetFileType(
             break;
         }
 
-    }
-    else {
-        //
-        // Not compressed, check mz header.
-        //
-        if (*((BYTE*)FileBuffer) == 'M' &&
-            *((BYTE*)FileBuffer + 1) == 'Z'
-            )
-        {
-            Result = ftMZ;
-        }
     }
     return Result;
 }

--- a/Source/sxsexp/sup.h
+++ b/Source/sxsexp/sup.h
@@ -30,7 +30,6 @@ typedef enum _CFILE_TYPE {
     ftDCM,
     ftDCS,
     ftDCX,
-    ftMZ,
     ftUnknown,
     ftMax
 } CFILE_TYPE;
@@ -165,7 +164,8 @@ BOOL supInitCabinetDecompressionAPI(
     _Inout_ PSUP_DECOMPRESSOR Decompressor);
 
 CFILE_TYPE supGetFileType(
-    _In_ PVOID FileBuffer);
+    _In_ PVOID FileBuffer,
+    _In_ ULONG fileSize);
 
 LPWSTR supPrintHash(
     _In_reads_bytes_(Length) LPBYTE Buffer,


### PR DESCRIPTION
I noticed that in some places, last error isn't set properly or can be overridden (e.g. line 638 before the changes).

In addition to the improved error handling, I introduced two behavior changes:
* Unknown files (including MZ) are skipped and not copied, and this isn't considered an error.
* Processing of files in a folder stops on first error.

I prefer this behavior as I mostly use the tool with a single folder as following:
```
sxsexp.exe C:\decompres_in_place C:\decompres_in_place
```

If you think that the current behavior is useful too, let me know and perhaps we can add a flag for it.

BTW thanks for SXSEXP :)